### PR TITLE
Adding totalClaim

### DIFF
--- a/DUSDLock.sol
+++ b/DUSDLock.sol
@@ -32,6 +32,7 @@ contract DUSDLock {
     uint256 public totalInvest;
     uint256 public totalWithdrawn;
     uint256 public totalRewards;
+    uint256 public totalClaim;
 
     //keeps track of the total rewards per deposit since the beginning of the contract, number can only go up
     //is used for rewards calculation. as the total rewards for a specific deposits is (rewardsPerDeposit - rewardsPerDepositOnDeposit)*depositSize
@@ -129,6 +130,7 @@ contract DUSDLock {
         require(claimed > 0,"DUSDLock: no rewards to claim");
         LockEntry storage entry= investments[msg.sender][batchId];
         entry.claimedRewards += claimed;
+        totalClaim += claimed;
         coin.safeTransfer(msg.sender, claimed);
 
         emit RewardsClaimed(msg.sender, claimed);


### PR DESCRIPTION
@kuegi i really like the combination of both sides. 
Removing to withdraw partial funds, makes the whole SC safer by removing complexity. 

Just added the totalClaim, i know, its not needed to calc anything inside the SC, however, for dapps it can show more analytics and brings some insights of the SC from the claims ppl are making. 

So far, i checked the code, looks fine from my side. Will do some testing tomorrow. 

*sorry, i added a new line on the end of the SC, its already committed. Maybe remove it. 